### PR TITLE
Remove /monitor endpoint from status.perma.cc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,6 @@ CLOUDFLARE_ANALYTICS_ENDPOINT=https://api.cloudflare.com/client/v4/graphql
 CF_ZONE=
 CF_API_TOKEN=
 PERMA_DAILY_LINK_COUNTS_ENDPOINT=https://api.perma-stage.org/v1/internal/daily_link_counts/
-PERMA_ARCHIVES_ENDPOINT=https://api.perma-stage.org/v1/public/archives/
 PERMA_API_KEY=
 DAILY_LINK_LOOKBACK_DAYS=7
 REQUEST_TIMEOUT=10

--- a/monitor.py
+++ b/monitor.py
@@ -1,6 +1,4 @@
 import os
-import requests
-from datetime import datetime
 from flask import Flask, render_template, jsonify
 from dotenv import load_dotenv
 
@@ -25,81 +23,3 @@ def perma_status(up="up!", message=""):
         return render_template("index.html", up=up, message=message)
     except Exception:
         return jsonify({"error": "missing template"}), 500
-
-
-def age(objects, now, f):
-    return (
-        now - datetime.strptime(
-            f(
-                [
-                    o['creation_timestamp']
-                    for o in objects if o['capture_time']
-                ]
-            ), "%Y-%m-%dT%H:%M:%S.%fZ"
-        )
-    ).total_seconds()
-
-
-@app.route("/monitor")
-def perma_monitor():
-    """ hit the Perma API and get the last {limit} captures for analysis """
-    thresholds = {"unfinished": 25, "statistic": 0.9}
-    base = os.getenv('PERMA_ARCHIVES_ENDPOINT')
-    timeout = int(os.getenv('REQUEST_TIMEOUT'))
-    limit = 50
-    offset = 0
-    url = f'{base}?limit={limit}&offset={offset}'
-
-    report = {"status": [], "messages": []}
-
-    try:
-        objects = requests.get(url, timeout=timeout).json()['objects']
-    except Exception as e:
-        report["status"].append("PROBLEM_PENDING")
-        report["messages"].append(f"API unavailable: {e}")
-        return jsonify(report=report)
-
-    pending = sum(
-        [
-            any([
-                "pending" in c['status']
-                for c in o['captures']
-                if not c['user_upload']
-            ])
-            for o in objects
-        ]
-    )
-
-    # what is the ratio of seconds from now to the last completed capture to
-    # the seconds from now to the oldest capture within {limit} captures ago?
-    now = datetime.utcnow()
-    if pending != limit:
-        try:
-            oldest = age(objects, now, min)
-            newest = age(objects, now, max)
-            statistic = newest / oldest
-        except Exception as e:
-            report["status"].append("PROBLEM_PENDING")
-            report["messages"].append(f"Couldn't get capture ages: {e}")
-            return jsonify(report=report)
-        if statistic != 1.0 and statistic > thresholds["statistic"]:
-            report["status"].append("PROBLEM_LOWUSAGE")
-            msg = f"statistic for time to last successful capture is {statistic}"
-            report["messages"].append(msg)
-    else:
-        statistic = "n/a"
-
-    if pending > thresholds["unfinished"]:
-        report["status"].append("PROBLEM_PENDING")
-        msg = f"{pending} uncompleted captures in the last {limit}"
-        report["messages"].append(msg)
-
-    if not report["status"]:
-        report["status"] = ["OK"]
-
-    output = {
-        "unfinished": pending,
-        "statistic": statistic,
-        "report": report
-    }
-    return jsonify(**output)


### PR DESCRIPTION
Once https://github.com/harvard-lil/salt/pull/9 lands, there will be no remaining users of https://status.perma.cc/monitor that I can discover. I'm pretty sure there are no other users, since access logs for the previous EC2 instance (up through May 12) show only the cron traffic we know about.

This fully removes that route, so it isn't an ongoing source of maintenance needs or log noise.

Note: there's a PROBLEM_LOWUSAGE statistic calculated in this code, which I'm pretty sure was never monitored.

Future work: with this gone, status.perma.cc can potentially just be an nginx app or github pages or something. I didn't pull that thread yet.